### PR TITLE
refactor: 処理を分割し関数として再定義する

### DIFF
--- a/main2.py
+++ b/main2.py
@@ -29,6 +29,28 @@ WHERE
 """
 
 
+def setup_parser():
+    """argparseのパーサをセットアップし定義を返す関数
+
+    Returns:
+        argparse.ArgumentParser: 設定済みのパーサーオブジェクト
+
+    """
+    parser = argparse.ArgumentParser(
+        description="都道府県を指定して、該当の市区長村名と面積をCSV形式で取得する。(指定なしの場合は東京都が指定される)"
+    )
+    parser.add_argument(
+        "-p",
+        "--prefecture",
+        type=str,
+        default="東京都",
+        help="都道府県名を入力してください。",
+        metavar="PREFECTURE_NAME",  # ヘルプメッセージでの表示名を指定
+    )
+
+    return parser
+
+
 def main(prefecture_name):
     conn = None  # connを初期化
     try:
@@ -89,16 +111,9 @@ def main(prefecture_name):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="都道府県を指定して、該当の市区長村名と面積をCSV形式で取得する。(指定なしの場合は東京都が指定される)"
-    )
-    parser.add_argument(
-        "-p",
-        "--prefecture",
-        type=str,
-        default="東京都",
-        help="都道府県名を入力してください。",
-        metavar="PREFECTURE_NAME",  # ヘルプメッセージでの表示名を指定
-    )
+    # パーサオブジェクトを生成
+    parser = setup_parser()
+    # 取得したパーサオブジェクトを使って引数を解析
     args = parser.parse_args()
+    # 解析結果をmainに渡す
     main(args.prefecture)


### PR DESCRIPTION
## Why
`main2.py`は`main()`関数で全ての処理が記載されているため、再利用度が低くなってしまっている。
処理を分割し関数に切り分けることで機能単位で管理しやすい状態を目指す。

## What
`mian()`の処理を以下に分割する。

- オプション引数を管理する（`argparse`のパーサをセットアップし、定義する）
- データベースとの接続を行（データベース接続(coon)とSQLを受け取り、実行し結果を返す）
- 実行結果をCSV保存する（データとファイル名を受け取り、CSVファイルに保存する）
- 処理の流れを制御する（上記の関数を順番に呼び出し、データの受け渡しを行う）

## チェックリスト

- `setup_parser()`
  - 役割: `argparse`のパーサをセットアップし、定義する
  - 引数: なし
  - 戻り値: 設定済みの`parser`オブジェクト
- `fetch_data`(cur, params)`:
  - 役割: データベース接続(`conn`)とSQLを受け取り、実行し結果を返す。 データとファイル名を受け取り、CSVファイルに保存する
  - 戻り値: なし
- `mian(args.prefecture) `:
  - 役割: 上記の関数を順番に呼び出し、データの受け渡しを行う
  - 引数: args.prefecture
  - 戻り値: なし